### PR TITLE
Fundig for open collective added

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: abap-observability-tools


### PR DESCRIPTION
Funding added for https://opencollective.com/abap-observability-tools
At least until open collective could be a fiscal host for GitHub sponsors in Europe