### PR TITLE
Prometheus Converter: Replace "/" in metric-name

### DIFF
--- a/src/zamp_converter/zcl_amp_conv_prom_keyvalue.clas.abap
+++ b/src/zamp_converter/zcl_amp_conv_prom_keyvalue.clas.abap
@@ -19,8 +19,12 @@ CLASS zcl_amp_conv_prom_keyvalue IMPLEMENTATION.
 
     LOOP AT metric_store ASSIGNING FIELD-SYMBOL(<metric>).
 
+      "replace / by _ because Prometheus does not like / in the "metric-name"
+      DATA(conv_metric_key) = <metric>-metric_key.
+      REPLACE ALL OCCURRENCES OF '/' IN conv_metric_key WITH '_'.
+
       converted_metrics = converted_metrics &&
-                          |{ sy-sysid }_{ sy-mandt }_{ <metric>-metric_scenario }_{ <metric>-metric_group }_{ <metric>-metric_key } { <metric>-metric_value }| &&
+                          |{ sy-sysid }_{ sy-mandt }_{ <metric>-metric_scenario }_{ <metric>-metric_group }_{ conv_metric_key } { <metric>-metric_value }| &&
                           cl_abap_char_utilities=>newline.
 
     ENDLOOP.


### PR DESCRIPTION
This PR replaces `/` by `_` because Prometheus does not like slashes in the "metric-name"

related issue:
closes #200 

In case of a metric:
- [ ] docs created/updated
- [ ] example dashboard created/updated
